### PR TITLE
Hw06 thread fix

### DIFF
--- a/hw06/brain/viz.cc
+++ b/hw06/brain/viz.cc
@@ -219,6 +219,7 @@ activate (GtkApplication *app,
 void
 viz_hit(float range, float angle)
 {
+    GDK_THREADS_ENTER();
     guard _gg(mx);
 
     int ww, hh;
@@ -247,6 +248,7 @@ viz_hit(float range, float angle)
     */
 
     draw_brush(drawing_area, xx, yy);
+    GDK_THREADS_LEAVE();
 }
 
 int

--- a/hw06/brain/viz.cc
+++ b/hw06/brain/viz.cc
@@ -214,6 +214,7 @@ activate (GtkApplication *app,
                           | GDK_POINTER_MOTION_MASK);
 
     gtk_widget_show_all(window);
+    gdk_threads_init();
 }
 
 void


### PR DESCRIPTION
GTK or GDK has its own internal mutex handling,

Rarely, what can happen is that the mx mutex is returned from draw_cb before the GDK mutex has been returned.

When draw_cb is called it isn't called just by itself, it has a parent function that calls it. This parent function is the one that cannot be called at the same time gtk_widget_queue_draw_area is called.

So draw_cb is run the mutex is obtained, draw_cb finishes and the mutex is returned, but the parent function hasn't finished yet and we are still in an unsafe configuration even though mx is unlocked.

GTK has an internal drawing mutex that is triggered when the thread is safe this is the function (even though it is deprecated).