### PR TITLE
fix to advertising too much causing queue to crash

### DIFF
--- a/hw06/brain/robot.cc
+++ b/hw06/brain/robot.cc
@@ -63,7 +63,7 @@ Robot::Robot(int argc, char* argv[], void (*cb)(Robot*))
     node = NodePtr(new Node());
     node->Init();
 
-    vel_pub = node->Advertise<msgs::Any>("~/tankbot0/vel_cmd");
+    vel_pub = node->Advertise<msgs::Any>("~/tankbot0/vel_cmd", 50);
     vel_pub->WaitForConnection();
 
     cout << "advertise on " << vel_pub->GetTopic() << endl;

--- a/hw06/plugins/tank_control/tank_control.cc
+++ b/hw06/plugins/tank_control/tank_control.cc
@@ -111,7 +111,7 @@ public:
                   << this->stat_sub->GetTopic() << std::endl;
 
         string pose_topic = "~/" + model_name + "/pose";
-        this->pose_pub = this->node->Advertise<msgs::PoseStamped>(pose_topic);
+        this->pose_pub = this->node->Advertise<msgs::PoseStamped>(pose_topic, 50);
         std::cerr << "Advertised pose" << std::endl;
 
         std::cerr << "tank control loaded" << std::endl;


### PR DESCRIPTION
**Bug:** After a little while running Gazebo, the queue for things being advertised gets full and the robot stops responding because of it. 

**Why this disrupted:** with no mistake, the robot would get overloaded and stop responding to commands as I was trying to map the full map

**Why the fix is correct:** now we only advertise every 50 milliseconds, which significantly reduces the load to the advertising queue and lets you run gazebo uninterrupted for longer. 