### PR TITLE
set angle error to 0

### DIFF
--- a/hw06/brain/robot.cc
+++ b/hw06/brain/robot.cc
@@ -55,7 +55,7 @@ degrade(float xx, int ee)
 
 Robot::Robot(int argc, char* argv[], void (*cb)(Robot*))
     : on_update(cb), task_done(false), stamp(0.0f),
-      err_x(5), err_y(0), err_t(3), err_l(1), err_r(0)
+      err_x(5), err_y(0), err_t(0), err_l(1), err_r(0)
 {
     srand(getpid()^time(0));
 


### PR DESCRIPTION
Constructs Robots with an err_t of 0 without removing the error functionality.