### PR TITLE
Update viz.cc

### DIFF
--- a/hw06/brain/viz.cc
+++ b/hw06/brain/viz.cc
@@ -236,7 +236,8 @@ viz_hit(float range, float angle)
     //guard _gg(mx);
     g_mutex_lock(&mutex_interface);
 
-    int ww, hh;
+    int ww = 0;
+    int hh = 0;
     gtk_window_get_size(GTK_WINDOW(window), &ww, &hh);
     //cout << "window: " << ww << "," << hh << endl;
 


### PR DESCRIPTION
The bug was that `ww` and `hh` variables in the `viz.cc` file were uninitialized.  Even after the `gtk_window_get_size` function was called, these variables were still temporarily uninitialized.  Therefore, trying to access them caused a segfault which lead to debugging time early in the assignment when trying to render walls.  Simply initializing them to `0` fixed the problem sufficiently.