### PR TITLE
Remove Degrading Velocity Commands

### DIFF
--- a/hw06/brain/robot.cc
+++ b/hw06/brain/robot.cc
@@ -139,8 +139,8 @@ Robot::done()
 void
 Robot::set_vel(double lvel, double rvel)
 {
-    lvel = clamp(-5, degrade(lvel, err_l), 5);
-    rvel = clamp(-5, degrade(rvel, err_r), 5);
+    lvel = clamp(-5, lvel, 5);
+    rvel = clamp(-5, rvel, 5);
     int xx = 128 + int(lvel * 25.0);
     int yy = 128 + int(rvel * 25.0);
     auto msg = msgs::ConvertAny(xx * 256 + yy);


### PR DESCRIPTION
1.) what the bug was: Error should only be in sensor data, not in motion.

2.) why that disrupted doing the assignment: It makes it much harder to navigate

3.) why your fix is the right thing: It removes the degrade modifier from velocity values--doesn't touch anything else.