### PR TITLE
Changing Robot x and y to be public

### DIFF
--- a/hw08/brain/robot.hh
+++ b/hw08/brain/robot.hh
@@ -12,6 +12,8 @@ class Robot {
   public:
     void (*on_update)(Robot*);
 
+    float pos_x;
+    float pos_y;
     float range;
     float pos_t;
     cv::Mat frame;
@@ -30,8 +32,6 @@ class Robot {
     void on_pose(ConstPoseStampedPtr &msg);
 
   private:
-    float pos_x;
-    float pos_y;
     bool task_done;
 
     gazebo::transport::NodePtr node;


### PR DESCRIPTION
The Bug: The robot's x and y sensor readings were private.

Disruption: These sensor readings are needed for the robot to perform A Star Search for a path to the goal.

The fix: Make the sensor readings public so that they can be accessed in the brain program.