### PR TITLE
adding clamp to robot.hh so that it does not give undefined error when building

### DIFF
--- a/hw08/brain/robot.hh
+++ b/hw08/brain/robot.hh
@@ -8,6 +8,8 @@
 
 #include <opencv2/core/mat.hpp>
 
+double clamp(double, double, double);
+
 class Robot {
   public:
     void (*on_update)(Robot*);


### PR DESCRIPTION
 When trying to use clamp in brain.cc clamp is undefined because it is not in the robot.hh header. This results in make errors.

Adding clamp back into the header fixes this issue. It adds the declaration for the function which is implemented in robot.cc but never declared in robot.hh
