### PR TITLE
hw08 resolution fix

### DIFF
--- a/hw08/models/camera_sensor/model.sdf
+++ b/hw08/models/camera_sensor/model.sdf
@@ -6,7 +6,7 @@
       <inertial>
         <mass>0.1</mass>
       </inertial>
-      
+
       <visual name="visual">
         <geometry>
           <box>
@@ -20,7 +20,7 @@
           </script>
         </material>
       </visual>
-      
+
       <collision name="collision">
         <pose>0 0 -0.0145 0 0 0</pose>
         <geometry>
@@ -29,13 +29,13 @@
           </box>
         </geometry>
       </collision>
-      
+
       <sensor name='camera' type='camera'>
         <camera>
           <horizontal_fov>1.3962634</horizontal_fov>
           <image>
-            <width>800</width>
-            <height>800</height>
+            <width>100</width>
+            <height>100</height>
           </image>
           <clip>
             <near>0.02</near>
@@ -45,10 +45,10 @@
         <always_on>1</always_on>
         <update_rate>10</update_rate>
         <visualize>1</visualize>
-        
+
         <plugin name="camera_controller" filename="libCameraPlugin.so"></plugin>
       </sensor>
-      
-    </link>  
+
+    </link>
   </model>
 </sdf>


### PR DESCRIPTION
**Bug description** 
High resolution for hw08 starter code causes errors in viewing and output from the camera

**Fix**
Lower the resolution from 800 by 800 to 100 by 100

**Why this is the right fix**
Lower resolution is less computational intensive and helps reduce the camera lag
